### PR TITLE
Reduce the size of the container further

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM nginx:1.13.8-alpine
 
 ADD constraints.txt /root/constraints.txt
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # The following packages are required to get httpbin/brotlipy/cffi installed
 #     openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev
 # Symlinking /usr/lib/libstdc++.so.6 to /usr/lib/libstdc++.so is specifically required for brotlipy
 RUN set -x && \
-    apk add --no-cache openssl ca-certificates py-pip openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev && \
+    apk add --no-cache openssl ca-certificates python2 py-setuptools py-pip openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev && \
     update-ca-certificates && \
     ln -s /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so && \
     mkdir -p /root/ca/certs /root/ca/private /root/ca/newcerts && \
@@ -31,8 +33,10 @@ RUN set -x && \
     cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
     cp /root/ca/client.ansible.http.tests-cert.pem /usr/share/nginx/html/client.pem && \
     cp /root/ca/private/client.ansible.http.tests-key.pem /usr/share/nginx/html/client.key && \
-    pip install -c /root/constraints.txt gunicorn httpbin && \
-    apk del openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev
+    pip install --no-compile -c /root/constraints.txt gunicorn httpbin && \
+    apk del ca-certificates py-pip openssl-dev python2-dev libffi-dev gcc libstdc++ make musl-dev && \
+    rm -rf /root/.cache/pip && \
+    find /usr/lib/python2.7 -type f -regex ".*\.py[co]" -delete
 
 ADD services.sh /services.sh
 ADD nginx.sites.conf /etc/nginx/conf.d/default.conf

--- a/services.sh
+++ b/services.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-gunicorn -D httpbin:app
-nginx -g "daemon off;"
+/usr/bin/gunicorn -D httpbin:app
+/usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
This PR does the following:

1. sets `PYTHONDONTWRITEBYTECODE` to avoid writing bytecode
1. Installs `python2` and `py-setuptools` to avoid uninstalling those later
1. Uninstalls `py-pip` after we have installed packages
1. Remove pip cache
1. Delete any `pyc` or `pyo` files added from `apk add`
1. Use `--no-compile` with pip to prevent writing bytecode

This reduces the size of the image from 96MB to 59MB.

The `uri` and `get_url` tests pass with these changes.