### PR TITLE
Added GSSAPI auth endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,39 @@
-FROM nginx:1.19.2-alpine
+ARG CONTAINER_VERSION=1.19.2-alpine
+
+# builder used to create a dynamic spnego auth module
+# https://gist.github.com/hermanbanken/96f0ff298c162a522ddbba44cad31081
+FROM nginx:${CONTAINER_VERSION} AS builder
+
+ENV SPNEGO_AUTH_COMMIT_ID=72c8ee04c81f929ec84d5a6d126f789b77781a8c
+
+RUN set -x && \
+    NGINX_VERSION="$( nginx -v 2>&1 | awk -F/ '{print $2}' )" && \
+    NGINX_CONFIG="$( nginx -V 2>&1 | sed -n -e 's/^.*arguments: //p' )" && \
+    wget "http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" -O nginx.tar.gz && \
+    wget https://github.com/stnoonan/spnego-http-auth-nginx-module/archive/${SPNEGO_AUTH_COMMIT_ID}.tar.gz -O spnego-http-auth.tar.gz && \
+    apk add --no-cache --virtual .build-deps \
+        gcc \
+        libc-dev \
+        make \
+        pcre-dev \
+        zlib-dev \
+        krb5-dev \
+        && \
+    mkdir /usr/src && \
+    tar -xzC /usr/src -f nginx.tar.gz && \
+    tar -xzvf spnego-http-auth.tar.gz && \
+    SPNEGO_AUTH_DIR="$( pwd )/spnego-http-auth-nginx-module-${SPNEGO_AUTH_COMMIT_ID}" && \
+    cd "/usr/src/nginx-${NGINX_VERSION}" && \
+    ./configure --with-compat "${NGINX_CONFIG}" --add-dynamic-module="${SPNEGO_AUTH_DIR}" && \
+    make modules && \
+    cp objs/ngx_*_module.so /usr/lib
+
+# Create the actual httptester container
+FROM nginx:${CONTAINER_VERSION}
 
 ADD constraints.txt /root/constraints.txt
+ADD krb5.conf /root/krb5.conf
+COPY --from=builder /usr/lib/ngx_*_module.so /usr/lib/nginx/modules/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -8,7 +41,22 @@ ENV PYTHONDONTWRITEBYTECODE=1
 #     openssl-dev python3-dev libffi-dev gcc libstdc++ make musl-dev
 # Symlinking /usr/lib/libstdc++.so.6 to /usr/lib/libstdc++.so is specifically required for brotlipy
 RUN set -x && \
-    apk add --no-cache openssl ca-certificates py3-pip py3-setuptools py3-wheel openssl-dev python3-dev libffi-dev gcc libstdc++ make musl-dev && \
+    apk add --no-cache \
+        ca-certificates \
+        gcc \
+        krb5-libs \
+        krb5-server \
+        libffi-dev \
+        libstdc++ \
+        make \
+        musl-dev \
+        openssl \
+        openssl-dev \
+        py3-pip \
+        py3-setuptools \
+        py3-wheel \
+        python3-dev \
+        && \
     update-ca-certificates && \
     ln -s /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so && \
     mkdir -p /root/ca/certs /root/ca/private /root/ca/newcerts && \
@@ -48,11 +96,23 @@ RUN set -x && \
     apk del openssl-dev py3-pip py3-wheel python3-dev libffi-dev gcc libstdc++ make musl-dev && \
     rm -rf /root/.cache/pip && \
     find /usr/lib/python3.8 -type f -regex ".*\.py[co]" -delete && \
-    find /usr/lib/python3.8 -type d -name "__pycache__" -delete
+    find /usr/lib/python3.8 -type d -name "__pycache__" -delete && \
+    echo "Microsoft Rulz" > /usr/share/nginx/html/gssapi && \
+    echo -e "load_module /usr/lib/nginx/modules/ngx_http_auth_spnego_module.so;\n$( cat /etc/nginx/nginx.conf )" > /etc/nginx/nginx.conf && \
+    cp /root/krb5.conf /etc/krb5.conf && \
+    PASSWORD="$( < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c30 )" && \
+    echo -e "${PASSWORD}\n${PASSWORD}" | /usr/sbin/kdb5_util create -r HTTP.TESTS && \
+    echo -e "*/admin@HTTP.TESTS\t*" > /var/lib/krb5kdc/kadm5.acl && \
+    kadmin.local -q "addprinc -randkey HTTP/ansible@HTTP.TESTS" && \
+    kadmin.local -q "addprinc -randkey HTTP/ansible.http.tests@HTTP.TESTS" && \
+    kadmin.local -q "ktadd -k /etc/nginx.keytab HTTP/ansible@HTTP.TESTS" && \
+    kadmin.local -q "ktadd -k /etc/nginx.keytab HTTP/ansible.http.tests@HTTP.TESTS" && \
+    chmod 660 /etc/nginx.keytab && \
+    chown root:nginx /etc/nginx.keytab
 
 ADD services.sh /services.sh
 ADD nginx.sites.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80 443
+EXPOSE 80 88 443 749
 
 CMD ["/services.sh"]

--- a/krb5.conf
+++ b/krb5.conf
@@ -1,0 +1,14 @@
+[libdefaults]
+  default_realm = HTTP.TESTS
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+
+[realms]
+  HTTP.TESTS = {
+    kdc = localhost
+    admin_server = localhost
+  }
+
+[domain_realm]
+  .http.tests = HTTP.TESTS
+  http.tests = HTTP.TESTS

--- a/nginx.sites.conf
+++ b/nginx.sites.conf
@@ -26,6 +26,13 @@ server {
         alias /usr/share/nginx/html/client.pem;
     }
 
+    location =/gssapi {
+        auth_gss on;
+        auth_gss_keytab /etc/nginx.keytab;
+        auth_gss_allow_basic_fallback off;
+        alias /usr/share/nginx/html/gssapi;
+    }
+
     location =/ssl_client_verify {
         return 200 "ansible.http.tests:$ssl_client_verify";
     }

--- a/services.sh
+++ b/services.sh
@@ -1,3 +1,11 @@
 #!/bin/sh
+
+if [ -z ${KRB5_PASSWORD} ]; then
+    echo "No KRB5_PASSWORD provided for the admin account."
+    exit 1
+fi
+
+kadmin.local -q "addprinc -pw ${KRB5_PASSWORD} admin"
+/usr/sbin/krb5kdc
 gunicorn -D httpbin:app
 nginx -g "daemon off;"


### PR DESCRIPTION
This adds an endpoint `/gssapi` that is protected by GSSAPI authentication (Kerberos). It also includes a KDC on the container so that Ansible can test Kerberos authentication in the `httptester` tests.