### PR TITLE
Add keyUsage extension for CA certs

### DIFF
--- a/create_certs.sh
+++ b/create_certs.sh
@@ -15,7 +15,7 @@ create_ca() {
     mkdir -p "${ca}/certs" "${ca}/private" "${ca}/newcerts"
     echo 1000 > "${ca}/serial"
     touch "${ca}/index.txt"
-    sed "s|\./demoCA|${ca}|g" /etc/ssl/openssl.cnf > "${ca}/openssl.cnf"
+    sed "s|\./demoCA|${ca}|g" /etc/ssl/openssl.cnf | sed "s|# keyUsage = cRLSign, keyCertSign|keyUsage = cRLSign, keyCertSign|g" > "${ca}/openssl.cnf"
     openssl req -new -x509 -nodes -extensions v3_ca \
       -config "${ca}/openssl.cnf" -days "${days}" -subj "${subj}/CN=${name}" -out "${ca}/cacert.pem" -keyout "${ca}/private/cakey.pem"
 }


### PR DESCRIPTION
Right now the CA certficiates generated do not have the keyUsage extension. Excerpt from the openssl.cnf:
```
[ v3_ca ]

# Extensions for a typical CA
[...]

# Key usage: this is typical for a CA certificate. However since it will
# prevent it being used as an test self-signed certificate it is best
# left out by default.
# keyUsage = cRLSign, keyCertSign
```
This causes problems with Python 3.13: https://github.com/ansible-collections/community.crypto/pull/768#issuecomment-2166653041

This PR uncomments the `keyUsage` line. With this change, the tests in https://github.com/ansible-collections/community.crypto/pull/768 pass.
